### PR TITLE
Add deployment of a service under test Docker container into the same…

### DIFF
--- a/Scripts/CustomTools/tools/RESTler/config.json
+++ b/Scripts/CustomTools/tools/RESTler/config.json
@@ -3,7 +3,7 @@
 	"run" : {
 		"command" : "/bin/sh", 
 		"arguments" : ["-c",
-			"dotnet /raft/agent/RestlerAgent.dll --agent-name ${RAFT_CONTAINER_NAME} --job-id ${RAFT_JOB_ID} --task-config-path ${RAFT_WORK_DIRECTORY}/task-config.json --work-directory ${RAFT_WORK_DIRECTORY} --restler-path /RESTler --app-insights-instrumentation-key ${RAFT_APP_INSIGHTS_KEY} --output-sas \"${RAFT_SB_OUT_SAS}\""
+			"sleep $RAFT_STARTUP_DELAY; dotnet /raft/agent/RestlerAgent.dll --agent-name ${RAFT_CONTAINER_NAME} --job-id ${RAFT_JOB_ID} --task-config-path ${RAFT_WORK_DIRECTORY}/task-config.json --work-directory ${RAFT_WORK_DIRECTORY} --restler-path /RESTler --app-insights-instrumentation-key ${RAFT_APP_INSIGHTS_KEY} --output-sas \"${RAFT_SB_OUT_SAS}\""
 		]
 	},
 	"idle" : {

--- a/Scripts/Tests/bvt-petstore.py
+++ b/Scripts/Tests/bvt-petstore.py
@@ -1,0 +1,182 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+import requests
+import time
+
+cli_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),'..', '..', 'cli')
+sys.path.append(cli_path)
+import raft
+from raft_sdk.raft_service import RaftCLI
+from raft_sdk.raft_common import RaftDefinitions
+from raft_sdk.raft_deploy import azure_function_keys
+
+def webhooks_test_url(subscription_id, resource_group, function):
+    keys = azure_function_keys(subscription_id, resource_group, function, "webhooks-trigger-test")
+    return f"https://{function}.azurewebsites.net/api/test?{keys['default']}"
+
+def webhook_triggers_results(job_id, test_url):
+    webhook_triggers_response = requests.get(test_url + "&jobId=" + job_id)
+    if webhook_triggers_response.ok:
+        triggers = json.loads(webhook_triggers_response.text)
+        for t in triggers:
+            j = json.loads(t)
+            yield j[0]
+    else:
+        raise Exception(webhook_triggers_response.text)
+
+def time_span(t_start, t_end):
+    return time.strftime("%H:%M:%S", time.gmtime(t_end - t_start))
+
+def bvt(cli, definitions):
+    print('Getting available wehook events')
+    webhook_events = cli.list_available_webhooks_events()
+    try:
+        test_url = webhooks_test_url(definitions.subscription, definitions.resource_group, definitions.test_infra)
+        for event in webhook_events:
+            print(f'Setting webhook for {event}')
+            compile_webhook = cli.set_webhooks_subscription('petstore-compile', event, test_url)
+            fuzz_webhook = cli.set_webhooks_subscription('petstore-fuzz', event, test_url)
+
+        added_compile = cli.list_webhooks('petstore-compile', event)
+        if len(added_compile) == 0:
+            raise Exception('Expected petstore-compile webhooks not to be empty after creation')
+
+        added_fuzz = cli.list_webhooks('petstore-fuzz', event)
+        if len(added_fuzz) == 0:
+            raise Exception('Expected petstore-fuzz webhooks not to be empty after creation')
+
+        t_pre_compile = time.time()
+
+        print('Compile')
+        compile_config_path = os.path.abspath(os.path.join(cli_path, 'samples', 'restler', 'self-contained', 'swagger-petstore', 'restler.compile.json'))
+
+        compile_config = raft.RaftJobConfig(file_path=compile_config_path)
+        compile_job = cli.new_job(compile_config)
+        cli.poll(compile_job['jobId'], 10)
+
+        #calculate compile duration
+        t_pre_fuzz = time.time()
+        timespan_pre_fuzz = time_span(t_pre_compile, t_pre_fuzz)
+        after_compile_pre_fuzz = cli.list_jobs(timespan_pre_fuzz)
+
+        n = 0
+        for x in after_compile_pre_fuzz:
+            if x['jobId'] == compile_job['jobId']:
+                n += 1
+            if x['agentName'] == compile_job['jobId']:
+                if x['state'] != 'Completed':
+                    raise Exception('Expected job to be in completed state when retrieved job list.'
+                                    f'{after_compile_pre_fuzz}')
+
+        if n != 2:
+            raise Exception('Expected 2 after compile job step'
+                            f' for job {compile_job["jobId"]}'
+                            f' got {n}'
+                            f' {after_compile_pre_fuzz}')
+
+        print('Fuzz')
+        fuzz_config_path = os.path.abspath(os.path.join(cli_path, 'samples', 'restler', 'self-contained', 'swagger-petstore', 'restler.fuzz.json'))
+        subs = {}
+        subs['{compile.jobId}'] = compile_job['jobId']
+        fuzz_config = raft.RaftJobConfig(file_path=fuzz_config_path, substitutions=subs)
+        fuzz_config.config['duration'] = '00:20:00'
+        fuzz_job = cli.new_job(fuzz_config)
+        cli.poll(fuzz_job['jobId'], 10)
+
+        #calculate fuzz duration
+        timespan_post_fuzz = time_span(t_pre_fuzz, time.time())
+        after_fuzz = cli.list_jobs(timespan_post_fuzz)
+
+        #validate list jobs
+        m = 0
+        for x in after_fuzz:
+            if x['jobId'] == fuzz_job['jobId']:
+                m += 1
+
+            if x['agentName'] == fuzz_job['jobId']:
+                if x['state'] != 'Completed':
+                    raise Exception('Expected job to be in completed state when retrieved job list.'
+                                    f'{after_fuzz}')
+        
+        if m != 2:
+            raise Exception('Expected 2 after compile job step'
+                            f' for job {fuzz_job["jobId"]}'
+                            f' got {m}'
+                            f' {after_fuzz}')
+
+
+        print('Validating webhook posted triggers')
+        compile_webhook_triggers = webhook_triggers_results(compile_job['jobId'], test_url)
+        for r in compile_webhook_triggers:
+            if r['EventType'] == 'BugFound':
+                raise Exception(f'Compile step produced BugFound event')
+
+        fuzz_webhook_triggers = webhook_triggers_results(fuzz_job['jobId'], test_url)
+
+        bug_found_events = []
+        job_status_events = []
+
+        for r in fuzz_webhook_triggers:
+            if r['EventType'] == 'BugFound':
+                bug_found_events.append(r)
+            elif r['EventType'] == 'JobStatus':
+                job_status_events.append(r)
+            else:
+                raise Exception(f'Unhandled webhook trigger event type {r["EventType"]} : {r}')
+
+        if len(job_status_events) == 0:
+            raise Exception('Job did not post any job status events webhooks')
+
+        print('Validating that bugs posted events matches total bugs found in job status')
+        total_bugs_found = 0
+        for r in job_status_events:
+            if r['Data']['State'] == 'Completed' and r['Data']['AgentName'] != r['Data']['JobId']:
+                total_bugs_found += r['Data']['Metrics']['TotalBugBucketsCount']
+
+        print(f'Total bugs found: {total_bugs_found}')
+        print(f'Number of Bug found events: {len(bug_found_events)}')
+        if total_bugs_found != len(bug_found_events):
+            raise Exception(f"Total bugs found does not match number of bug found webhook triggered events {total_bugs_found} and {len(bug_found_events)}")
+
+    except Exception as ex:
+        print(f"FAIL: {ex}")
+        raise ex
+    finally:
+        for event in webhook_events:
+            print(f'Cleaning up webhook {event}')
+            cli.delete_webhook('petstore-compile', event)
+            cli.delete_webhook('petstore-fuzz', event)
+
+        deleted_compile = cli.list_webhooks('petstore-compile', event)
+        if len(deleted_compile) > 0:
+            raise Exception('Expected petstore-compile webhooks to be empty after deletion, instead got %s', deleted_compile)
+
+        deleted_fuzz = cli.list_webhooks('petstore-fuzz', event)
+        if len(deleted_fuzz) > 0:
+            raise Exception('Expected petstore-fuzz webhooks to be empty after deletion, instead got %s', deleted_compile)
+
+
+
+if __name__ == "__main__":
+    formatter = argparse.ArgumentDefaultsHelpFormatter
+    parser = argparse.ArgumentParser(description='bvt', formatter_class=formatter)
+    raft.add_defaults_and_secret_args(parser)
+    args = parser.parse_args()
+
+    if args.defaults_context_json:
+        print(f"Loading defaults from command line: {args.defaults_context_json}")
+        defaults = json.loads(args.defaults_context_json)
+    else:
+        with open(args.defaults_context_path, 'r') as defaults_json:
+            defaults = json.load(defaults_json)
+
+    definitions = RaftDefinitions(defaults)
+    defaults['secret'] = args.secret
+    cli = RaftCLI(defaults)
+    bvt(cli, definitions)

--- a/cli/raft-tools/tools/RESTler/config.json
+++ b/cli/raft-tools/tools/RESTler/config.json
@@ -3,13 +3,14 @@
 	"run" : {
 		"command" : "/bin/sh", 
 		"arguments" : ["-c",
-			"dotnet /raft/agent/RestlerAgent.dll --agent-name ${RAFT_CONTAINER_NAME} --job-id ${RAFT_JOB_ID} --task-config-path ${RAFT_WORK_DIRECTORY}/task-config.json --work-directory ${RAFT_WORK_DIRECTORY} --restler-path /RESTler --app-insights-instrumentation-key ${RAFT_APP_INSIGHTS_KEY} --output-sas \"${RAFT_SB_OUT_SAS}\""
+			"sleep $RAFT_STARTUP_DELAY; dotnet /raft/agent/RestlerAgent.dll --agent-name ${RAFT_CONTAINER_NAME} --job-id ${RAFT_JOB_ID} --task-config-path ${RAFT_WORK_DIRECTORY}/task-config.json --work-directory ${RAFT_WORK_DIRECTORY} --restler-path /RESTler --app-insights-instrumentation-key ${RAFT_APP_INSIGHTS_KEY} --output-sas \"${RAFT_SB_OUT_SAS}\""
 		]
 	},
 	"idle" : {
 		"command" : "/bin/sh",
 		"arguments" : ["-c", "echo DebugMode; while true; do sleep 100000; done;"]
 	},
+	"shell" : "/bin/sh",
 	"environmentVariables" : {
 		"RESTLER_TELEMETRY_OPTOUT" : "0"	
 	}

--- a/cli/raft-tools/tools/ZAP/config.json
+++ b/cli/raft-tools/tools/ZAP/config.json
@@ -3,7 +3,7 @@
 	"run" : {
 		"command" : "bash", 
 		"arguments" : ["-c", 
-		    "touch /.dockerenv; cd $RAFT_TOOL_RUN_DIRECTORY; ln -s $RAFT_WORK_DIRECTORY /zap/wrk; python3 run.py install; python3 run.py" ]
+		    "sleep $RAFT_STARTUP_DELAY; touch /.dockerenv; cd $RAFT_TOOL_RUN_DIRECTORY; ln -s $RAFT_WORK_DIRECTORY /zap/wrk; python3 run.py install; python3 run.py" ]
 	},
 	"idle" : {
 		"command" : "bash",

--- a/cli/raft-tools/tools/ZAP/scan.py
+++ b/cli/raft-tools/tools/ZAP/scan.py
@@ -134,7 +134,7 @@ def run_zap(token):
     shutil.copy('/zap/zap.out', '/zap/wrk/zap.out')
 
     utils.report_status_completed()
-    if r < 2:
+    if r <= 2:
         return 0
     else:
         return r

--- a/cli/samples/restler/self-contained/swagger-petstore/restler.compile.json
+++ b/cli/samples/restler/self-contained/swagger-petstore/restler.compile.json
@@ -1,0 +1,36 @@
+{
+  "swaggerLocation": {
+    "URL" : "http://localhost:8080/api/swagger.json"
+  },
+  "webhook": {
+    "name": "petstore-compile",
+    "metadata": {
+	    "action" : "compile"
+    }
+  },
+  "testTargets" : {
+    "targets" : [
+      {
+        "Container" : "swaggerapi/petstore",
+        "Port" : 8080,
+        "ExpectedDurationUntilReady" : "00:02:00",
+        "Shell" : "/bin/sh",
+        "OutputFolder" : "petstore",
+        "PostRun" : {
+          "Command" : "/bin/sh", 
+          "Arguments" : ["-c", "cp /var/log/*-requests.log $RAFT_WORK_DIRECTORY"],
+          "ExpectedRunDuration" : "00:00:10"
+        }
+      }
+    ]
+  },
+  "tasks": [
+    {
+      "toolName": "RESTler",
+      "outputFolder": "compile",
+      "toolConfiguration": {
+        "task": "Compile"
+      }
+    }
+  ]
+}

--- a/cli/samples/restler/self-contained/swagger-petstore/restler.fuzz.json
+++ b/cli/samples/restler/self-contained/swagger-petstore/restler.fuzz.json
@@ -1,0 +1,52 @@
+{
+  "host": "localhost",
+  "webhook": {
+    "name": "petstore-fuzz",
+    "metadata": {
+      "app" : "petstore",
+      "swagger_version" : "v2",
+      "action" : "fuzz"	
+    }
+  },
+
+  "readonlyFileShareMounts": [
+    {
+      "FileShareName": "{compile.jobId}",
+      "MountPath": "/job-compile"
+    }
+  ],
+
+ "testTargets" : { 
+    "targets" : [
+      {
+        "Container" : "swaggerapi/petstore",
+        "Port" : 8080,
+        "ExpectedDurationUntilReady" : "00:02:00",
+        "Shell" : "/bin/sh",
+        "OutputFolder" : "petstore",
+        "PostRun" : {
+          "Command" : "/bin/sh", 
+          "Arguments" : ["-c", "cp /var/log/*-requests.log $RAFT_WORK_DIRECTORY"],
+          "ExpectedRunDuration" : "00:00:10"
+        }
+      }
+    ]
+  },
+  "tasks": [
+    {
+      "toolName": "RESTler",
+      "outputFolder": "fuzz",
+      "duration": "00:10:00",
+      "toolConfiguration": {
+        "task": "Fuzz",
+        "runConfiguration": {
+          "targetEndpointConfiguration" : {
+            "Port" : 8080 
+          },
+          "useSsl" : false,
+          "inputFolderPath": "/job-compile/compile"
+        }
+      }
+    }
+  ]
+}

--- a/cli/samples/restler/self-contained/swagger-petstore/restler.test.json
+++ b/cli/samples/restler/self-contained/swagger-petstore/restler.test.json
@@ -1,0 +1,52 @@
+{
+  "host": "localhost",
+
+  "webhook": {
+    "name": "petstore",
+    "metadata": {
+      "app" : "petstore",
+      "swagger_version" : "v2",
+      "action" : "test"	
+    }
+  },
+  "readonlyFileShareMounts": [
+    {
+      "FileShareName": "{compile.jobId}",
+      "MountPath": "/job-compile"
+    }
+  ],
+
+ "testTargets" : { 
+    "targets" : [
+      {
+        "Container" : "swaggerapi/petstore",
+        "Port" : 8080,
+        "ExpectedDurationUntilReady" : "00:00:30",
+        "Shell" : "/bin/sh",
+        "OutputFolder" : "petstore",
+        "PostRun" : {
+          "Command" : "/bin/sh", 
+          "Arguments" : ["-c", "cp /var/log/*-requests.log $RAFT_WORK_DIRECTORY"],
+          "ExpectedRunDuration" : "00:00:10"
+        }
+      }
+    ]
+  },
+
+  "tasks": [
+    {
+      "toolName": "RESTler",
+      "outputFolder": "test-fuzz-lean",
+      "toolConfiguration": {
+        "task": "Test",
+        "runConfiguration": {
+          "useSsl" : false,
+          "targetEndpointConfiguration" : {
+            "Port" : 8080
+          },
+          "inputFolderPath": "/job-compile/compile"
+        }
+      }
+    }
+  ]
+}

--- a/cli/samples/restler/self-contained/swagger-petstore/run.py
+++ b/cli/samples/restler/self-contained/swagger-petstore/run.py
@@ -1,0 +1,54 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+ 
+import pathlib
+import sys
+import os
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(cur_dir, '..', '..', '..', '..'))
+from raft_sdk.raft_service import RaftCLI, RaftJobConfig, RaftJobError
+
+def run(compile, test, fuzz):
+    # instantiate RAFT CLI
+    cli = RaftCLI()
+
+    # Create compilation job configuration
+    compile_job_config = RaftJobConfig(file_path=compile)
+    # add webhook metadata that will be included in every triggered webhook by Compile job
+    compile_job_config.add_metadata({"branch":"wizbangFeature"})
+    print('Compile')
+    # submit a new job with the Compile config and get new job ID
+    compile_job = cli.new_job(compile_job_config)
+    # wait for a job with ID from compile_job to finish the run
+    cli.poll(compile_job['jobId'])
+
+    # use compile job as input for fuzz job
+    subs = {}
+    subs['{compile.jobId}'] = compile_job['jobId']
+
+    test_job_config = RaftJobConfig(file_path=test, substitutions=subs)
+    print('Test')
+    # create new fuzz job configuration
+    test_job = cli.new_job(test_job_config)
+    # wait for job ID from fuzz_job to finish the run
+    cli.poll(test_job['jobId'])
+
+    # create a new job config with Fuzz configuration JSON
+    fuzz_job_config = RaftJobConfig(file_path=fuzz, substitutions=subs)
+    print('Fuzz')
+    # add webhook metadata that will included in every triggered webhook by Fuzz job
+    fuzz_job_config.add_metadata({"branch":"wizbangFeature"})
+    # create new fuzz job configuration
+    fuzz_job = cli.new_job(fuzz_job_config)
+
+    # wait for job ID from fuzz_job to finish the run
+    cli.poll(fuzz_job['jobId'])
+
+if __name__ == "__main__":
+    try:
+        run(os.path.join(cur_dir, "restler.compile.json"),
+            os.path.join(cur_dir, "restler.test.json"), 
+            os.path.join(cur_dir, "restler.fuzz.json"))
+    except RaftJobError as ex:
+        print(f'ERROR: {ex.message}')

--- a/cli/samples/restler/self-contained/swagger-petstore3/restler.compile.json
+++ b/cli/samples/restler/self-contained/swagger-petstore3/restler.compile.json
@@ -1,0 +1,44 @@
+{
+  "swaggerLocation": {
+    "URL" : "http://localhost:8082/api/v3/openapi.json"
+  },
+
+  "resources": {
+    "Cores": 4,
+    "MemoryGBs": 8
+  },
+
+  "testTargets" : {
+    "resources" : {
+      "Cores" : 2,
+      "MemoryGBs" : 4
+    },
+    "targets" : [
+      {
+        "Container" : "swaggerapi/petstore3",
+        "Port" : 8082,
+        "ExpectedDurationUntilReady" : "00:00:30",
+        "Run" : {
+          "Command" : "java",
+          "Arguments" : ["-jar", "/swagger-petstore/jetty-runner.jar", "--log", "/var/log/yyyy_mm_dd-requests.log", "--port", "8082", "/swagger-petstore/server.war"]
+        },
+        "PostRun" : {
+          "Command" : "/bin/sh", 
+          "Arguments" : ["-c", "cp /var/log/*-requests.log $RAFT_WORK_DIRECTORY"],
+          "ExpectedRunDuration" : "00:00:10"
+        },
+        "Shell" : "/bin/sh",
+        "OutputFolder" : "petstore3"
+        }
+    ]
+  },
+  "tasks": [
+    {
+      "toolName": "RESTler",
+      "outputFolder": "compile",
+      "toolConfiguration": {
+        "task": "Compile"
+      }
+    }
+  ]
+}

--- a/cli/samples/restler/self-contained/swagger-petstore3/restler.test.json
+++ b/cli/samples/restler/self-contained/swagger-petstore3/restler.test.json
@@ -1,0 +1,52 @@
+{
+  "host": "localhost",
+
+  "resources": {
+    "Cores": 4,
+    "MemoryGBs": 8
+  },
+
+  "readonlyFileShareMounts": [
+    {
+      "FileShareName": "{compile.jobId}",
+      "MountPath": "/job-compile"
+    }
+  ],
+
+ "testTargets" : { 
+    "resources" : {
+      "Cores" : 2,
+      "MemoryGBs" : 4
+    },
+    "targets" : [
+      {
+        "Container" : "swaggerapi/petstore3",
+        "Port" : 8080,
+        "ExpectedDurationUntilReady" : "00:00:30",
+        "PostRun" : {
+          "Command" : "/bin/sh", 
+          "Arguments" : ["-c", "cp /var/log/*-requests.log $RAFT_WORK_DIRECTORY"],
+          "ExpectedRunDuration" : "00:00:10"
+        },
+        "Shell" : "/bin/sh",
+        "OutputFolder" : "zap_petstore3"
+      }
+    ]
+  },
+  "tasks": [
+    {
+      "toolName": "RESTler",
+      "outputFolder": "test",
+      "toolConfiguration": {
+        "task": "test",
+        "runConfiguration": {
+          "targetEndpointConfiguration" : {
+            "Port" : 8080 
+          },
+          "useSsl" : false,
+          "inputFolderPath": "/job-compile/compile"
+        }
+      }
+    }
+  ]
+}

--- a/cli/samples/restler/self-contained/swagger-petstore3/restler.zap.fuzz.json
+++ b/cli/samples/restler/self-contained/swagger-petstore3/restler.zap.fuzz.json
@@ -1,0 +1,71 @@
+{
+  "host": "localhost",
+
+  "resources": {
+    "Cores": 4,
+    "MemoryGBs": 8
+  },
+
+  "readonlyFileShareMounts": [
+    {
+      "FileShareName": "{compile.jobId}",
+      "MountPath": "/job-compile"
+    }
+  ],
+
+ "testTargets" : { 
+    "resources" : {
+      "Cores" : 2,
+      "MemoryGBs" : 4
+    },
+    "targets" : [
+      {
+        "Container" : "swaggerapi/petstore3",
+        "Port" : 8081,
+        "ExpectedDurationUntilReady" : "00:02:00",
+        "Run" : {
+          "Command" : "/bin/sh",
+          "Arguments" : ["-c", "java -jar /swagger-petstore/jetty-runner.jar --log $RAFT_WORK_DIRECTORY/yyyy_mm_dd-requests.log --port 8081 /swagger-petstore/server.war"]
+        },
+        "Shell" : "/bin/sh",
+        "OutputFolder" : "restler_petstore3"
+      },
+      {
+        "Container" : "swaggerapi/petstore3",
+        "Port" : 8080,
+        "ExpectedDurationUntilReady" : "00:00:30",
+        "PostRun" : {
+          "Command" : "/bin/sh", 
+          "Arguments" : ["-c", "cp /var/log/*-requests.log $RAFT_WORK_DIRECTORY"],
+          "ExpectedRunDuration" : "00:00:10"
+        },
+        "Shell" : "/bin/sh",
+        "OutputFolder" : "zap_petstore3"
+      }
+    ]
+  },
+  "tasks": [
+    {
+      "toolName": "RESTler",
+      "outputFolder": "fuzz",
+      "duration": "00:30:00",
+      "toolConfiguration": {
+        "task": "Fuzz",
+        "runConfiguration": {
+          "targetEndpointConfiguration" : {
+            "Port" : 8081 
+          },
+          "useSsl" : false,
+          "inputFolderPath": "/job-compile/compile"
+        }
+      }
+    },
+    {
+      "toolName" : "ZAP",
+      "outputFolder" : "zap",
+      "swaggerLocation": {
+        "URL" : "http://localhost:8080/api/v3/openapi.json"
+      }
+    }
+  ]
+}

--- a/cli/samples/restler/self-contained/swagger-petstore3/run.py
+++ b/cli/samples/restler/self-contained/swagger-petstore3/run.py
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+ 
+import pathlib
+import sys
+import os
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(cur_dir, '..', '..', '..', '..'))
+from raft_sdk.raft_service import RaftCLI, RaftJobConfig, RaftJobError
+
+def run(compile, test, fuzz):
+    # instantiate RAFT CLI
+    cli = RaftCLI()
+
+    # Create compilation job configuration
+    compile_job_config = RaftJobConfig(file_path=compile)
+    print('Compile')
+    # submit a new job with the Compile config and get new job ID
+    compile_job = cli.new_job(compile_job_config)
+    # wait for a job with ID from compile_job to finish the run
+    cli.poll(compile_job['jobId'])
+
+    # use compile job as input for fuzz job
+    subs = {}
+    subs['{compile.jobId}'] = compile_job['jobId']
+
+    test_job_config = RaftJobConfig(file_path=test, substitutions=subs)
+    print('Test')
+    # create new fuzz job configuration
+    test_job = cli.new_job(test_job_config)
+    # wait for job ID from fuzz_job to finish the run
+    cli.poll(test_job['jobId'])
+
+    # create a new job config with Fuzz configuration JSON
+    fuzz_job_config = RaftJobConfig(file_path=fuzz, substitutions=subs)
+    print('Fuzz')
+    # create new fuzz job configuration
+    fuzz_job = cli.new_job(fuzz_job_config)
+
+    # wait for job ID from fuzz_job to finish the run
+    cli.poll(fuzz_job['jobId'])
+
+if __name__ == "__main__":
+    try:
+        run(os.path.join(cur_dir, "restler.compile.json"),
+            os.path.join(cur_dir, "restler.test.json"), 
+            os.path.join(cur_dir, "restler.zap.fuzz.json"))
+    except RaftJobError as ex:
+        print(f'ERROR: {ex.message}')

--- a/cli/samples/zap/swagger-petstore3/zap.json
+++ b/cli/samples/zap/swagger-petstore3/zap.json
@@ -1,0 +1,30 @@
+{
+  "host": "localhost",
+
+  "testTargets" : {
+    "targets":
+      [
+        {
+          "Container" : "swaggerapi/petstore3",
+          "Port" : 8080,
+          "ExpectedDurationUntilReady" : "00:00:30",
+          "PostRun" : {
+            "Command" : "/bin/sh", 
+            "Arguments" : ["-c", "cp /var/log/*-requests.log $RAFT_WORK_DIRECTORY"],
+            "ExpectedRunDuration" : "00:00:10"
+          },
+          "Shell" : "/bin/sh",
+          "OutputFolder" : "zap_petstore3"
+      }
+    ]
+  },
+  "tasks": [
+    {
+      "toolName" : "ZAP",
+      "outputFolder" : "zap",
+      "swaggerLocation": {
+        "URL" : "http://localhost:8080/api/v3/openapi.json"
+      }
+    }
+  ]
+}

--- a/docs/how-to-onboard-a-tool.md
+++ b/docs/how-to-onboard-a-tool.md
@@ -159,6 +159,7 @@ been populated for you by the orchestration:
 | RAFT_RUN_CMD | The command text provided in the `command` parameter |
 | RAFT_TASK_INDEX | Array index of the task defined in job definition JSON blob
 | RAFT_SITE_HASH | RAFT deployment hash
+| RAFT_STARTUP_DELAY | How many seconds the tool should wait before starting
 
 *When the tool is uploaded to the file share via the cli command `python raft.py service upload-tools` a unique file share is created and mounted to the container as read-only. The path to the tool folder running the task within the file share is set in **RAFT_TOOL_RUN_DIRECTORY** environment variable.
 

--- a/src/APIService/ApiService/APIServiceTests/JobVerb_Tests_DeleteJob.fs
+++ b/src/APIService/ApiService/APIServiceTests/JobVerb_Tests_DeleteJob.fs
@@ -33,7 +33,7 @@ type DeleteJobTests() =
             let fakeMessageSender = Fixtures.createFakeMessageSender Raft.Message.ServiceBus.Queue.delete
 
             let jobStatusJson = File.ReadAllText("test-job-status.json")
-            let entity = JobStatusEntity(System.Guid.Parse("29211868-8178-4e81-9b8d-d52025b4c2d4").ToString(), "testAgent", jobStatusJson)
+            let entity = JobStatusEntity(System.Guid.Parse("29211868-8178-4e81-9b8d-d52025b4c2d4").ToString(), "testAgent", jobStatusJson, "Created")
 
             Raft.Utilities.raftStorage <- Fixtures.createFakeRaftStorage (Some entity)
 

--- a/src/APIService/ApiService/APIServiceTests/JobVerb_Tests_GetJobStatus.fs
+++ b/src/APIService/ApiService/APIServiceTests/JobVerb_Tests_GetJobStatus.fs
@@ -33,7 +33,7 @@ type GetJobStatusTests() =
     member this.``GET /jobs/restler succeeds`` () =
         async {
             let jobStatusJson = File.ReadAllText("test-job-status.json")
-            let entity = JobStatusEntity(Guid.Parse("29211868-8178-4e81-9b8d-d52025b4c2d4").ToString(), "29211868-8178-4e81-9b8d-d52025b4c2d4", jobStatusJson)
+            let entity = JobStatusEntity(Guid.Parse("29211868-8178-4e81-9b8d-d52025b4c2d4").ToString(), "29211868-8178-4e81-9b8d-d52025b4c2d4", jobStatusJson, "Created")
             Raft.Utilities.raftStorage <- Fixtures.createFakeRaftStorage (Some entity)
 
             let jobController = jobsController(Fixtures.createFakeTelemetryClient, Fixtures.createFakeLogger<jobsController>)

--- a/src/APIService/ApiService/APIServiceTests/JobVerb_Tests_ListJobStatuses.fs
+++ b/src/APIService/ApiService/APIServiceTests/JobVerb_Tests_ListJobStatuses.fs
@@ -30,7 +30,7 @@ type ListJobStatusesTests() =
     member this.``LIST /jobs/restler succeeds`` () =
         async {
             let jobStatusJson = File.ReadAllText("test-job-status.json")
-            let entity = JobStatusEntity(Guid.Parse("29211868-8178-4e81-9b8d-d52025b4c2d4").ToString(), "testAgent", jobStatusJson)
+            let entity = JobStatusEntity(Guid.Parse("29211868-8178-4e81-9b8d-d52025b4c2d4").ToString(), "testAgent", jobStatusJson, "Created")
             Raft.Utilities.raftStorage <- Fixtures.createFakeRaftStorage (Some entity)
 
             let jobController = jobsController(Fixtures.createFakeTelemetryClient, Fixtures.createFakeLogger<jobsController>)

--- a/src/APIService/ApiService/APIServiceTests/JobVerb_Tests_RePostJob.fs
+++ b/src/APIService/ApiService/APIServiceTests/JobVerb_Tests_RePostJob.fs
@@ -20,7 +20,7 @@ type jobsRePOSTTests() =
             let jobId = System.Guid.NewGuid().ToString()
 
             let jobStatusJson = File.ReadAllText("test-job-status.json")
-            let entity = JobStatusEntity(jobId, jobId, jobStatusJson)
+            let entity = JobStatusEntity(jobId, jobId, jobStatusJson, "Created")
             Raft.Utilities.raftStorage <- Fixtures.createFakeRaftStorage (Some entity)
             Raft.Utilities.toolsSchemas <- Map.empty.Add("RESTler", None)
 

--- a/src/APIService/ApiService/DTOs.fs
+++ b/src/APIService/ApiService/DTOs.fs
@@ -135,6 +135,41 @@ module DTOs =
             MemoryGBs : int
         }
 
+    [<CLIMutable>]
+    type Command =
+        {
+            Command : string
+            Arguments : string array
+            ExpectedRunDuration: Nullable<TimeSpan>
+        }
+
+    [<CLIMutable>]
+    type TestTargetDefinition =
+        {
+            [<Required>]
+            Container : string
+            Port : int
+            ExpectedDurationUntilReady: TimeSpan
+
+            IsIdling : Nullable<bool>
+
+            Run : Command
+            Idle : Command
+            PostRun : Command
+            OutputFolder : string
+            Shell : string
+
+            EnvironmentVariables : IDictionary<string, string>
+            KeyVaultSecrets : string array
+        }
+
+    [<CLIMutable>]
+    type TestTarget =
+        {
+            Resources : Resources
+            Targets : TestTargetDefinition array
+        }
+
     /// <summary>
     /// Webhook definition
     /// </summary>
@@ -181,6 +216,12 @@ module DTOs =
             /// </summary>
             [<Required>]
             Tasks : RaftTask array
+
+            /// <summary>
+            /// Deploy Services under test packaged as Docker container to the same
+            /// container grop as Tasks
+            /// </summary>
+            TestTargets : TestTarget
 
             /// <summary>
             /// Duration of the job; if not set, then job runs till completion (or forever).
@@ -231,8 +272,6 @@ module DTOs =
         {
             JobId : string
         }
-        
-
 
     // We need some way of designating that these types are returned to the customer
     // public? external? ReturnedJobId? 
@@ -248,10 +287,11 @@ module DTOs =
         | Creating = 0
         | Created = 1
         | Running = 2
-        | Completed = 3
-        | ManuallyStopped = 4
-        | Error = 5
-        | TimedOut = 6
+        | Completing = 3
+        | Completed = 4
+        | ManuallyStopped = 5
+        | Error = 6
+        | TimedOut = 7
 
     [<CLIMutable>]
     type RunSummary =

--- a/src/Agent/RESTlerAgent/RESTlerTypes.fs
+++ b/src/Agent/RESTlerAgent/RESTlerTypes.fs
@@ -28,10 +28,10 @@ module Engine =
             mutationsFilePath : string
 
             /// The IP of the endpoint being fuzzed
-            targetIp : string
+            targetIp : string option
 
             /// The port of the endpoint being fuzzed
-            targetPort : int
+            targetPort : int option
 
             /// The maximum fuzzing time in hours
             maxDurationHours : float option
@@ -125,9 +125,9 @@ module Engine =
             //override host defined in swagger for every request
             host: string option
 
-            target_ip: string
+            target_ip: string option
 
-            target_port : int
+            target_port : int option
 
             //in hours
             time_budget : float option
@@ -188,9 +188,9 @@ module Engine =
 
                 host = None
 
-                target_ip = ""
+                target_ip = None
 
-                target_port = 443
+                target_port = None
 
                 //in hours
                 time_budget = None

--- a/src/Contracts/Job.fs
+++ b/src/Contracts/Job.fs
@@ -16,6 +16,43 @@ type SwaggerLocation =
     | FilePath of string
 
 
+type Resources =
+    {
+        Cores : int
+        MemoryGBs : int
+    }
+
+type Command =
+    {
+        Command : string
+        Arguments : string array option
+        ExpectedRunDuration: System.TimeSpan option
+    }
+
+type TestTargetDefinition =
+    //accessible within conatiner group at localhost:port
+    {
+        Container : string
+        ExpectedDurationUntilReady: System.TimeSpan
+        Port : int
+
+        IsIdling : bool option
+        Run : Command option
+        Idle : Command option
+        PostRun : Command option
+        OutputFolder : string option
+        Shell : string option
+
+        EnvironmentVariables : Map<string, string> option
+        KeyVaultSecrets : string array option
+    }
+
+type TestTarget =
+    {
+        Resources : Resources
+        Targets : TestTargetDefinition array
+    }
+
 type RaftTask =
     {
         ToolName: string
@@ -41,17 +78,10 @@ type RaftTask =
         ToolConfiguration : Newtonsoft.Json.Linq.JObject
     }
 
-
 type FileShareMount =
     {
         FileShareName : string //any fileShare name from the service storage account
         MountPath : string //example "/my-job-config"
-    }
-
-type Resources =
-    {
-        Cores : int
-        MemoryGBs : int
     }
 
 type Webhook =
@@ -75,7 +105,10 @@ type JobDefinition =
 
         Resources : Resources
 
-        // !!NOTE!!: according to Azure Container spec, we can have up to 60 elements in this array
+
+        // !!NOTE!!: according to Azure Container spec, we can have up to 60 elements
+        // of TestTargets and Tasks combined
+        TestTargets : TestTarget option
         Tasks : RaftTask array
 
         /// Duration of the job; if not set, then job runs till completion

--- a/src/Contracts/JobEvents.fs
+++ b/src/Contracts/JobEvents.fs
@@ -9,6 +9,7 @@ type JobState =
     | Creating
     | Created
     | Running
+    | Completing
     | Completed
     | ManuallyStopped
     | Error
@@ -26,11 +27,19 @@ let ( ??> ) (s1: JobState) (s2: JobState) =
     | JobState.Running, (JobState.Creating | JobState.Created) -> true
     | JobState.Running, _ -> false
 
-    | JobState.ManuallyStopped, (JobState.Creating | JobState.Created | JobState.Running | JobState.Completed | JobState.Error) -> true
+    | JobState.ManuallyStopped,
+        ( JobState.Creating 
+        | JobState.Created 
+        | JobState.Running 
+        | JobState.Completing 
+        | JobState.Completed 
+        | JobState.Error) -> true
     | JobState.ManuallyStopped, _ -> false
 
+    | JobState.Completing, (JobState.Error | JobState.Completed) -> false
+
     | JobState.Completed , (JobState.Error | JobState.Completed) -> false
-    | (JobState.Completed | JobState.TimedOut | JobState.Error), _ -> true
+    | (JobState.Completing | JobState.Completed | JobState.TimedOut | JobState.Error), _ -> true
 
 type RunSummary =
     {

--- a/src/Contracts/StorageEntities.fs
+++ b/src/Contracts/StorageEntities.fs
@@ -6,10 +6,11 @@ module Raft.StorageEntities
 open Microsoft.Azure.Cosmos.Table
 
 let JobStatusTableName = "JobStatus"
-type JobStatusEntity(jobId, agentName, jobStatus) = 
+type JobStatusEntity(jobId, agentName, jobStatus, jobState) = 
     inherit TableEntity(partitionKey=jobId, rowKey=agentName)
-    new() = JobStatusEntity(null, null, null)
+    new() = JobStatusEntity(null, null, null, null)
     member val JobStatus : string = jobStatus with get, set
+    member val JobState : string = jobState with get, set
 
 
 let JobTableName = "Job" 


### PR DESCRIPTION
… container group as test tools

- Service under test, as long as it is in a Docker container, deployed in the same container group as test tools
- Service under test only needs to specify the port that it is listening on. Becomes accessible through localhost:port
- No public IP assigned to any of containers (can only communicate through localhost)
- Service under test has a post run execution to copy needed files to a persistent storage
- Add swagger petstore docker images deployed along with test tools as samples (RESTler and ZAP)
- Add petstore-bvt