### PR TITLE
fix zap requirements

### DIFF
--- a/cli/raft-tools/tools/ZAP/config.json
+++ b/cli/raft-tools/tools/ZAP/config.json
@@ -3,11 +3,14 @@
 	"run" : {
 		"command" : "bash", 
 		"arguments" : ["-c", 
-		    "sleep $RAFT_STARTUP_DELAY; touch /.dockerenv; cd $RAFT_TOOL_RUN_DIRECTORY; ln -s $RAFT_WORK_DIRECTORY /zap/wrk; python3 run.py install; python3 run.py" ]
+		    "sleep $RAFT_STARTUP_DELAY; cd $RAFT_TOOL_RUN_DIRECTORY; ln -s $RAFT_WORK_DIRECTORY /zap/wrk; python3 run.py install; python3 run.py" ]
 	},
 	"idle" : {
 		"command" : "bash",
 		"arguments" : ["-c", "echo DebugMode; while true; do sleep 100000; done;"]
+	},
+	"environmentVariables" :{
+		"IS_CONTAINERIZED" : "true"
 	}
 }
 

--- a/cli/raft-tools/tools/ZAP/requirements.txt
+++ b/cli/raft-tools/tools/ZAP/requirements.txt
@@ -1,2 +1,2 @@
-applicationinsights
-azure-servicebus
+applicationinsights~=0.11.9
+azure-servicebus~=0.50.3


### PR DESCRIPTION
This is fixes ZAP in v1 by pinning python requirements to the older, working ones.

Closing #67 