### PR TITLE
Expose dredd configuration values through RAFT job definition

### DIFF
--- a/cli/raft-tools/auth/node-js/msal/msal_token.js
+++ b/cli/raft-tools/auth/node-js/msal/msal_token.js
@@ -45,7 +45,7 @@ function get_token(client_id, tenant_id, secret, scopes, authority_uri, callback
     msalInstance.acquireTokenByClientCredential(accessTokenRequest).then(function(accessTokenResponse) {
         callback(null, accessTokenResponse.tokenType + ' ' + accessTokenResponse.accessToken);
     }).catch(function (error) {
-        log.error(error);
+        console.error(error);
         callback(error);
     })
 }

--- a/cli/raft-tools/tools/Dredd/schema.json
+++ b/cli/raft-tools/tools/Dredd/schema.json
@@ -1,0 +1,54 @@
+
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Dredd",
+        "version": "v2"
+    },
+    "paths": {},
+    "components": {
+        "schemas": {
+            "Dredd" : {
+                "type" : "object",
+                "properties" : {
+                    "sorted" : {
+                        "type" : "boolean",
+                        "description" : "Sorts requests in a sensible way so that objects are not modified before they are created. Order: CONNECT, OPTIONS, POST, GET, HEAD, PUT, PATCH, LINK, UNLINK, DELETE, TRACE."
+                    },
+                    "dry-run" : {
+                        "type" : "boolean",
+                        "description": "Boolean, do not run any real HTTP transaction"
+                    },
+                    "only" : {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description" : "Array of Strings, run only transaction that match these names"
+                    },
+                    "header" : {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description" : "Array of Strings, these strings are then added as headers (key:value) to every transaction"
+                    },
+                    "hookfiles" : {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description" : "Array of Strings, filepaths to files containing hooks (can use glob wildcards)"
+                    },
+                    "require" : {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description" : "String, When using nodejs hooks, require the given module before executing hooks"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cli/raft.py
+++ b/cli/raft.py
@@ -110,7 +110,7 @@ def run(args):
             skip_sp_deployment = args.get('skip_sp_deployment')
             service_cli.deploy(
                 args['sku'], skip_sp_deployment and skip_sp_deployment is True)
-        elif service_action == 'upload-tools':
+        elif service_action == 'upload-tools' or service_action == 'update':
             utils_file_share = f'{uuid.uuid4()}'
             service_cli.upload_utils(
                 utils_file_share, args.get('custom_tools_path'))
@@ -313,7 +313,7 @@ Clears the cache so re-authentication will be needed to use the CLI again.'''))
         formatter_class=argparse.RawTextHelpFormatter)
     service_parser.add_argument(
         'service-action',
-        choices=['deploy', 'restart', 'info', 'upload-tools'],
+        choices=['deploy', 'restart', 'info', 'upload-tools', 'update'],
         help=textwrap.dedent('''\
 deploy       - Deploys the service
 
@@ -322,7 +322,10 @@ restart      - Restarts the service updating the
 
 info         - Show the version of the service and the last time it was started
 
-upload-tools - Uploads the tool definitions to the service
+upload-tools - Uploads the tools definitions to the service
+
+update - Uploads the tools definitions to the service and
+         restarts service to get latest service components
 '''))
 
     allowed_skus = [

--- a/cli/samples/dredd/petstore/dredd.json
+++ b/cli/samples/dredd/petstore/dredd.json
@@ -29,7 +29,14 @@
       "tasks": [
         {
           "toolName" : "Dredd",
-          "outputFolder" : "dredd"
+          "outputFolder" : "dredd",
+          "toolConfiguration" : {
+            "dry-run" : true,
+            "only" : [],
+            "header" : [],
+            "hookfiles" : [],
+            "require" : null
+          }
         }
       ]
     }


### PR DESCRIPTION
- Add swagger scheman.json to dredd
- Expose 'header', 'dry-run', 'only', 'hookfiles', 'require' confgiuration values