### PR TITLE
Combine RESTler tasks into one config

### DIFF
--- a/Scripts/Tests/bvt-petstore3.py
+++ b/Scripts/Tests/bvt-petstore3.py
@@ -117,8 +117,8 @@ def bvt(cli, definitions, subs):
                     raise Exception('Expected job to be in completed state when retrieved job list.'
                                     f'{after_fuzz}')
         
-        if m != 3:
-            raise Exception('Expected 3 after compile job step'
+        if m != 4:
+            raise Exception('Expected 4 after fuzz job step'
                             f' for job {fuzz_job["jobId"]}'
                             f' got {m}'
                             f' {after_fuzz}')

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,4 +1,4 @@
-msal~=1.4.3
+msal~=1.9.0
 requests~=2.24.0
 tabulate~=0.8.7
 pyyaml~=5.3.1

--- a/cli/samples/restler/self-contained/swagger-petstore3/fuzz.json
+++ b/cli/samples/restler/self-contained/swagger-petstore3/fuzz.json
@@ -75,6 +75,28 @@
           ],
           "endpoint" : "http://localhost:8082"
         }
+      },
+      {
+        "toolName" : "RESTler",
+        "outputFolder" : "restlerCombined",
+        "targetConfiguration" : {
+          "apiSpecifications": [
+            "http://localhost:8082/api/v3/openapi.json"
+          ],
+          "endpoint" : "http://localhost:8082"
+        },
+        "toolConfiguration": {
+          "tasks" : [
+            {"task": "Compile"},
+            {
+              "task": "Fuzz",
+              "RunConfiguration" : {
+                "useSsl" : false,
+                "Duration" : "00:08:00"
+              }
+            }
+          ]
+        }
       }
     ]
   }

--- a/cli/samples/restler/single-task-compile-test-fuzz/run.json
+++ b/cli/samples/restler/single-task-compile-test-fuzz/run.json
@@ -1,0 +1,34 @@
+{
+  "namePrefix": "sample-",
+  "webhook": {
+    "name": "sample"
+  },
+  
+  "testTasks": {
+    "targetConfiguration" : {
+      "apiSpecifications": [
+        "https://petstore.swagger.io/v2/swagger.json"
+      ]
+    },
+    "tasks": [
+      {
+        "toolName": "RESTler",
+        "outputFolder": "restler-run",
+        "toolConfiguration": {
+          "tasks": [
+                {"task": "Compile"}, 
+                
+                {"task" : "Test"}, 
+                
+                {
+                    "task" : "Fuzz",
+                    "runConfiguration" : {
+                      "Duration" : "00:10:00"
+                    }
+                }
+            ]
+        }
+      }
+    ]
+  }
+}

--- a/src/APIService/ApiService/DTOs.fs
+++ b/src/APIService/ApiService/DTOs.fs
@@ -305,6 +305,7 @@ module DTOs =
         | Error = 6
         | TimedOut = 7
         | ReStarted = 8
+        | TaskCompleted = 9
 
     [<CLIMutable>]
     type RunSummary =

--- a/src/Agent/RESTlerAgent/AgentMain.fs
+++ b/src/Agent/RESTlerAgent/AgentMain.fs
@@ -212,7 +212,7 @@ let createRESTlerEngineParameters
         TargetPort = port
 
         /// The maximum fuzzing time in hours
-        MaxDurationHours = task.Duration |> Option.map(fun d -> d.TotalHours)
+        MaxDurationHours = (Option.orElse runConfiguration.Duration task.Duration) |> Option.map(fun d -> d.TotalHours)
 
         /// The authentication options, when tokens are required
         RefreshableTokenOptions =
@@ -572,7 +572,13 @@ let main argv =
         | Result.Error err -> failwith err
 
         let task: Raft.Job.RaftTask = Json.Compact.deserializeFile taskConfigurationPath
-        let restlerPayload : RESTlerPayload = Json.Compact.deserialize (task.ToolConfiguration.ToString())
+        
+        let restlerPayloads : RESTlerPayload array =
+            match Json.Compact.tryDeserialize (task.ToolConfiguration.ToString()) with
+            | Choice1Of2 p -> [|p|]
+            | Choice2Of2(_)->
+                let payloads: RESTlerPayloads = Json.Compact.deserialize (task.ToolConfiguration.ToString())
+                payloads.tasks
 
         do! jobEventSender.SendRaftJobEvent jobId
                 ({
@@ -588,7 +594,7 @@ let main argv =
                     ResultsUrl = None
                 }: Raft.JobEvents.JobStatus)
 
-        printfn "Got job configuration message: %A" restlerPayload
+        printfn "Got job configuration message: %A" restlerPayloads
 
         let customDictionaryPath = workDirectory ++ "customDictionary.json"
         let grammarPy = workDirectory ++ "grammar.py"
@@ -694,98 +700,106 @@ let main argv =
                                             ResultsUrl = None
                                         } : Raft.JobEvents.BugFound)
             }
+        
 
-        let getResultReportingInterval() =
-            let resultAnalyzerReportInterval =
-                let defaultInterval = TimeSpan.FromSeconds(60.0)
-                match restlerPayload.AgentConfiguration with
-                | Some agentConfig ->
-                    match agentConfig.ResultsAnalyzerReportTimeSpanInterval, task.Duration with
-                    | None, _ ->
-                        printfn "Result analyzer interval is not set, using default"
-                        Some defaultInterval
-                    | Some ts, Some duration when ts >= duration ->
-                        printfn "Result analyzer interval (%A) is longer than job duration (%A). Using this as not set" ts duration
-                        None
-                    | Some ts, _ ->
-                        printfn "Result analyzer interval is set to %A" ts
-                        Some ts
-                | None -> Some defaultInterval
-            resultAnalyzerReportInterval
+        let combinedMetrics = ref Raft.JobEvents.RunSummary.Empty
+        for restlerPayload in restlerPayloads do
+            // execution id is used for RESTler specific metrics only
+            // Each loop iteration represents a RESTler run. Thus requires
+            // new execution ID
+            let executionId = Guid.NewGuid()
 
-        let test (testType: string) checkerOptions (jobConfiguration: RunConfiguration) =
-            async {
-                let resultAnalyzerReportInterval = getResultReportingInterval()
-                do! installCertificatesIfNeeded task
-                let engineParameters = createRESTlerEngineParameters workDirectory grammarPy dictJson task checkerOptions jobConfiguration
-                printfn "Starting RESTler test task"
+            let getResultReportingInterval() =
+                let resultAnalyzerReportInterval =
+                    let defaultInterval = TimeSpan.FromSeconds(60.0)
+                    match restlerPayload.AgentConfiguration with
+                    | Some agentConfig ->
+                        match agentConfig.ResultsAnalyzerReportTimeSpanInterval, task.Duration with
+                        | None, _ ->
+                            printfn "Result analyzer interval is not set, using default"
+                            Some defaultInterval
+                        | Some ts, Some duration when ts >= duration ->
+                            printfn "Result analyzer interval (%A) is longer than job duration (%A). Using this as not set" ts duration
+                            None
+                        | Some ts, _ ->
+                            printfn "Result analyzer interval is set to %A" ts
+                            Some ts
+                    | None -> Some defaultInterval
+                resultAnalyzerReportInterval
 
-                let ignoreBugHashes =
-                    match jobConfiguration.IgnoreBugHashes with
-                    | None -> Set.empty
-                    | Some hs -> Set.ofArray hs
+            let test (testType: string) checkerOptions (jobConfiguration: RunConfiguration) =
+                async {
+                    let resultAnalyzerReportInterval = getResultReportingInterval()
+                    do! installCertificatesIfNeeded task
+                    let engineParameters = createRESTlerEngineParameters workDirectory grammarPy dictJson task checkerOptions jobConfiguration
+                    printfn "Starting RESTler test task"
 
-                do! Raft.RESTlerDriver.test testType restlerPath workDirectory engineParameters ignoreBugHashes onBugFound (report Raft.JobEvents.JobState.Running) (globalRunStartTime, resultAnalyzerReportInterval)
-            }
+                    let ignoreBugHashes =
+                        match jobConfiguration.IgnoreBugHashes with
+                        | None -> Set.empty
+                        | Some hs -> Set.ofArray hs
 
-        let fuzz (fuzzType:string) checkerOptions (jobConfiguration: RunConfiguration) =
-            async {
-                let resultAnalyzerReportInterval = getResultReportingInterval()
-                do! installCertificatesIfNeeded task
-                let engineParameters = createRESTlerEngineParameters workDirectory grammarPy dictJson task checkerOptions jobConfiguration
-                printfn "Starting RESTler fuzz task"
+                    do! Raft.RESTlerDriver.test testType restlerPath workDirectory engineParameters ignoreBugHashes onBugFound (report Raft.JobEvents.JobState.Running) (globalRunStartTime, resultAnalyzerReportInterval)
+                }
 
-                let ignoreBugHashes =
-                    match jobConfiguration.IgnoreBugHashes with
-                    | None -> Set.empty
-                    | Some hs -> Set.ofArray hs
+            let fuzz (fuzzType:string) checkerOptions (jobConfiguration: RunConfiguration) =
+                async {
+                    let resultAnalyzerReportInterval = getResultReportingInterval()
+                    do! installCertificatesIfNeeded task
+                    let engineParameters = createRESTlerEngineParameters workDirectory grammarPy dictJson task checkerOptions jobConfiguration
+                    printfn "Starting RESTler fuzz task"
 
-                do! Raft.RESTlerDriver.fuzz fuzzType restlerPath workDirectory engineParameters ignoreBugHashes onBugFound (report Raft.JobEvents.JobState.Running) (globalRunStartTime, resultAnalyzerReportInterval)
-            }
+                    let ignoreBugHashes =
+                        match jobConfiguration.IgnoreBugHashes with
+                        | None -> Set.empty
+                        | Some hs -> Set.ofArray hs
+
+                    do! Raft.RESTlerDriver.fuzz fuzzType restlerPath workDirectory engineParameters ignoreBugHashes onBugFound (report Raft.JobEvents.JobState.Running) (globalRunStartTime, resultAnalyzerReportInterval)
+                }
             
-        let replay replayLogFile (jobConfiguration: RunConfiguration) =
-            async {
-                //same command line parameters as fuzzing, except for fuzzing parameter pass sprintf "--replay_log %s" replayLogFilePath
-                let task =
-                    match task.TargetConfiguration with
-                    | None ->
-                        let taskConfigurationPath = jobConfiguration.InputFolderPath ++ ".." ++ ".." ++ ".." ++ IO.FileInfo(taskConfigurationPath).Name
-                        let prevTask: Raft.Job.RaftTask = Json.Compact.deserializeFile taskConfigurationPath
-                        {
-                            task with
-                                TargetConfiguration = prevTask.TargetConfiguration
-                        }
+            let replay replayLogFile (jobConfiguration: RunConfiguration) =
+                async {
+                    //same command line parameters as fuzzing, except for fuzzing parameter pass sprintf "--replay_log %s" replayLogFilePath
+                    let task =
+                        match task.TargetConfiguration with
+                        | None ->
+                            let taskConfigurationPath =
+                                match jobConfiguration.InputFolderPath with
+                                | None -> workDirectory ++ IO.FileInfo(taskConfigurationPath).Name
+                                | Some p -> p ++ ".." ++ ".." ++ ".." ++ IO.FileInfo(taskConfigurationPath).Name
 
-                    | _ -> task
+                            let prevTask: Raft.Job.RaftTask = Json.Compact.deserializeFile taskConfigurationPath
+                            {
+                                task with
+                                    TargetConfiguration = prevTask.TargetConfiguration
+                            }
+                        | _ -> task
 
-                do! installCertificatesIfNeeded task
-                let engineParameters = createRESTlerEngineParameters workDirectory grammarPy dictJson task [] jobConfiguration
-                printfn "Starting RESTler replay task"
-                return! Raft.RESTlerDriver.replay restlerPath workDirectory replayLogFile engineParameters
-            }
+                    do! installCertificatesIfNeeded task
+                    let engineParameters = createRESTlerEngineParameters workDirectory grammarPy dictJson task [] jobConfiguration
+                    printfn "Starting RESTler replay task"
+                    return! Raft.RESTlerDriver.replay restlerPath workDirectory replayLogFile engineParameters
+                }
 
-        let executionId = Guid.NewGuid()
-        telemetryClient.RestlerStarted(Raft.RESTlerDriver.RESTler.version, sprintf "%A" restlerPayload.Task, executionId, [])
-        // Start RESTler process with following flags
-        // compile, test, fuzz 
-        // --telemetryRootDirPath
-        let! state, details, exitCode, (experiment, summary) =
-            async {
-                try
-                    match restlerPayload.Task with
+        
+            telemetryClient.RestlerStarted(Raft.RESTlerDriver.RESTler.version, sprintf "%A" restlerPayload.Task, executionId, [])
+            let restlerTask =
+                match restlerPayload.Task with
+                | Some t -> t
+                | None -> failwithf "RESTler task is not set. "
+
+
+            // Start RESTler process with following flags
+            // compile, test, fuzz 
+            // --telemetryRootDirPath
+            let! state, details, exitCode, (experiment, summary) =
+                async {
+                    match restlerTask with
                     | TaskType.Compile ->
                         let compileConfiguration = 
-                                match restlerPayload.CompileConfiguration with
-                                | Some compileConfiguration -> compileConfiguration
-                                | None ->
-                                          // Return a default compilerConfiguration type
-                                          { InputJsonGrammarPath = None 
-                                            InputFolderPath = None
-                                            ReadOnlyFuzz = false
-                                            AllowGetProducers = false
-                                            UseRefreshableToken = false
-                                            MutationsSeed = None
-                                            CustomDictionary = None }
+                            match restlerPayload.CompileConfiguration with
+                            | Some compileConfiguration -> compileConfiguration
+                            | None -> CompileConfiguration.Empty
 
                         let restlerCompatibleMutations = 
                             createRESTlerCompilerMutations compileConfiguration.MutationsSeed compileConfiguration.CustomDictionary
@@ -800,235 +814,273 @@ let main argv =
                         | None -> do! compileSwaggerGrammar compileConfiguration
                         | Some p -> do! compileJsonGrammar (workDirectory ++ p) compileConfiguration
                         let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
-                        return Raft.JobEvents.Completed, None, 0, summary
+                        return Raft.JobEvents.TaskCompleted, None, 0, summary
 
                     | TaskType.Test ->
                         printfn "Running directed-smoke-test"
-                        match restlerPayload.RunConfiguration with
-                        | None -> return failwithf "Job-run configuration is not set for Test task for job payload: %A" restlerPayload
-                        | Some jobConfiguration ->
-                            copyDir jobConfiguration.InputFolderPath workDirectory (set [taskConfigurationPath])
-                            do! report Raft.JobEvents.Running (None, None)
-                            do! test "directed-smoke-test" [] jobConfiguration
-                            let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
-                            return Raft.JobEvents.Completed, None, 0, summary
+                        let jobConfiguration =
+                            match restlerPayload.RunConfiguration with
+                            | None -> RunConfiguration.Empty
+                            | Some jobConfiguration -> jobConfiguration
+                        match jobConfiguration.InputFolderPath with
+                        | Some p -> copyDir p workDirectory (set [taskConfigurationPath])
+                        | None -> ()
+                        do! report Raft.JobEvents.Running (None, None)
+                        do! test "directed-smoke-test" [] jobConfiguration
+                        let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
+                        return Raft.JobEvents.TaskCompleted, None, 0, summary
         
                     | TaskType.TestFuzzLean ->
                         printfn "Running directed-smoke-test"
-                        match restlerPayload.RunConfiguration with
-                        | None -> return failwithf "Job-run configuration is not set for Test task for job payload: %A" restlerPayload
-                        | Some jobConfiguration ->
-                            copyDir jobConfiguration.InputFolderPath workDirectory (set [taskConfigurationPath])
-                            do! report Raft.JobEvents.Running (None, None)
-                            let fuzzLeanCheckers = 
-                                [
-                                    ("--enable_checkers", "*")
-                                    ("--disable_checkers", "namespacerule")
-                                ]
-                            do! test "directed-smoke-test" fuzzLeanCheckers jobConfiguration
-                            let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
-                            return Raft.JobEvents.Completed, None, 0, summary
+                        let jobConfiguration =
+                            match restlerPayload.RunConfiguration with
+                            | None -> RunConfiguration.Empty
+                            | Some jobConfiguration -> jobConfiguration
+                        match jobConfiguration.InputFolderPath with
+                        | Some p -> copyDir p workDirectory (set [taskConfigurationPath])
+                        | None -> ()
+                        do! report Raft.JobEvents.Running (None, None)
+                        let fuzzLeanCheckers = 
+                            [
+                                ("--enable_checkers", "*")
+                                ("--disable_checkers", "namespacerule")
+                            ]
+                        do! test "directed-smoke-test" fuzzLeanCheckers jobConfiguration
+                        let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
+                        return Raft.JobEvents.TaskCompleted, None, 0, summary
 
                     | TaskType.Fuzz ->
                         printfn "Running bfs fuzz"
-                        match restlerPayload.RunConfiguration with
-                        | None -> return failwithf "Job-run configuration is not set for Compile task for job payload: %A" restlerPayload
-                        | Some jobConfiguration ->
-                            copyDir jobConfiguration.InputFolderPath workDirectory (set [taskConfigurationPath])
-                            do! report Raft.JobEvents.Running (None, None)
-                            let allCheckers = ["--enable_checkers", "*"]
-                            do! fuzz "bfs" allCheckers jobConfiguration
-                            let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
-                            return Raft.JobEvents.Completed, None, 0, summary
+                        let jobConfiguration =
+                            match restlerPayload.RunConfiguration with
+                            | None -> RunConfiguration.Empty
+                            | Some jobConfiguration -> jobConfiguration
+
+                        match jobConfiguration.InputFolderPath with
+                        | Some p -> copyDir p workDirectory (set [taskConfigurationPath])
+                        | None -> ()
+                        do! report Raft.JobEvents.Running (None, None)
+                        let allCheckers = ["--enable_checkers", "*"]
+                        do! fuzz "bfs" allCheckers jobConfiguration
+                        let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
+                        return Raft.JobEvents.TaskCompleted, None, 0, summary
 
                     | TaskType.FuzzBfsCheap ->
                         printfn "Running bfs-cheap fuzz"
-                        match restlerPayload.RunConfiguration with
-                        | None -> return failwithf "Job-run configuration is not set for Test task for job payload: %A" restlerPayload
-                        | Some jobConfiguration ->
-                            copyDir jobConfiguration.InputFolderPath workDirectory (set [taskConfigurationPath])
-                            do! report Raft.JobEvents.Running (None, None)
-                            let allCheckers = ["--enable_checkers", "*"]
-                            do! fuzz "bfs-cheap" allCheckers jobConfiguration
-                            let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
-                            return Raft.JobEvents.Completed, None, 0, summary
+                        let jobConfiguration = 
+                            match restlerPayload.RunConfiguration with
+                            | None -> RunConfiguration.Empty
+                            | Some jobConfiguration -> jobConfiguration
+
+                        match jobConfiguration.InputFolderPath with
+                        | Some p -> copyDir p workDirectory (set [taskConfigurationPath])
+                        | None -> ()
+                        do! report Raft.JobEvents.Running (None, None)
+                        let allCheckers = ["--enable_checkers", "*"]
+                        do! fuzz "bfs-cheap" allCheckers jobConfiguration
+                        let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
+                        return Raft.JobEvents.TaskCompleted, None, 0, summary
 
                     | TaskType.FuzzRandomWalk ->
                         printfn "Running random-walk fuzz"
-                        match restlerPayload.RunConfiguration with
-                        | None -> return failwithf "Job-run configuration is not set for Fuzz task for job payload: %A" restlerPayload
-                        | Some jobConfiguration ->
-                            copyDir jobConfiguration.InputFolderPath workDirectory (set [taskConfigurationPath])
-                            do! report Raft.JobEvents.Running (None, None)
-                            let allCheckers = ["--enable_checkers", "*"]
-                            do! fuzz "random-walk" allCheckers jobConfiguration
-                            let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
-                            return Raft.JobEvents.Completed, None, 0, summary
+                        let jobConfiguration =
+                            match restlerPayload.RunConfiguration with
+                            | None -> RunConfiguration.Empty
+                            | Some jobConfiguration -> jobConfiguration
+                        match jobConfiguration.InputFolderPath with
+                        | Some p ->  copyDir p workDirectory (set [taskConfigurationPath])
+                        | None -> ()
+                        do! report Raft.JobEvents.Running (None, None)
+                        let allCheckers = ["--enable_checkers", "*"]
+                        do! fuzz "random-walk" allCheckers jobConfiguration
+                        let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
+                        return Raft.JobEvents.TaskCompleted, None, 0, summary
 
                     | TaskType.Replay ->
-                        match restlerPayload.RunConfiguration with
-                        | None -> return failwithf "Job-run configuration is not set Replay task for job payload: %A" restlerPayload
-                        | Some replayRunConfiguration ->
-                            let replaySourcePath = replayRunConfiguration.InputFolderPath
-                            do! report Raft.JobEvents.Running (None, None)
+                        let replayRunConfiguration =
+                            match restlerPayload.RunConfiguration with
+                            | None -> RunConfiguration.Empty
+                            | Some replayRunConfiguration -> replayRunConfiguration
 
-                            let replayAndReport (bugs: IO.FileInfo seq) =
+                        let replaySourcePath = 
+                            match replayRunConfiguration.InputFolderPath with
+                            | Some p -> p
+                            | None -> failwithf "Do not know where to replay bugs from"
+                        do! report Raft.JobEvents.Running (None, None)
+
+                        let replayAndReport (bugs: IO.FileInfo seq) =
+                            async {
+                                let! existingBugBuckets = Raft.RESTlerDriver.getListOfBugsFromBugBuckets replaySourcePath
+
+                                let remapBugHashes (bugHashes : Raft.RESTlerTypes.Logs.BugHashes) =
+                                    bugHashes
+                                    |> Seq.map(fun (KeyValue(k, v)) -> v.file_path, k)
+                                    |> Map.ofSeq
+
+                                let bugs, fileNameToBugHashMap =
+                                    match replayRunConfiguration.IgnoreBugHashes, existingBugBuckets with
+                                    | None, None | Some _, None -> bugs, Map.empty
+                                        | None, Some existingBugs ->
+                                        bugs, (remapBugHashes existingBugs)
+
+                                    | Some ignoreHashes, Some existingBugs ->
+                                        let filesToIgnore = 
+                                            ignoreHashes 
+                                            |> Array.map(fun h ->
+                                                match Map.tryFind h existingBugs with
+                                                | None -> None
+                                                | Some b -> Some b.file_path
+                                            )
+                                            |> Array.filter Option.isSome
+                                            |> Array.map Option.get
+                                            |> Set.ofArray
+
+                                        let filteredBugs =
+                                            bugs
+                                            |> Seq.filter (fun b ->
+                                                not (filesToIgnore.Contains b.Name)
+                                            )
+                                        filteredBugs, (remapBugHashes existingBugs)
+
+                                let replaySummaryDetails = ResizeArray<string * string>()
+
+                                for bug in bugs do
+                                    printfn "Running replay on %s" bug.FullName
+                                    let! (experiment, replaySummary) = replay bug.FullName replayRunConfiguration
+                                    let summary =
+                                        match replaySummary with
+                                        | None ->
+                                            sprintf "%s : No results" bug.Name
+                                        | Some s ->
+                                            sprintf "%s/%s: %A" (Option.defaultValue "ExperimentNotSet" experiment) bug.Name (s.ResponseCodeCounts |> Map.toList)
+
+                                    let bugKey =
+                                        match Map.tryFind bug.Name fileNameToBugHashMap with
+                                        | None -> bug.Name
+                                        | Some h -> h
+                                    replaySummaryDetails.Add(bugKey, summary)
+                                    do! jobEventSender.SendRaftJobEvent jobId
+                                                ({
+                                                    AgentName = agentName
+                                                    Metadata = None
+                                                    Tool = "RESTler"
+                                                    JobId = jobId
+                                                    State = Raft.JobEvents.JobState.Running
+                                                    Metrics = None
+                                                    UtcEventTime = System.DateTime.UtcNow
+                                                    Details = Some (Map.ofSeq replaySummaryDetails)
+                                                    ResultsUrl = None
+                                                } : Raft.JobEvents.JobStatus)
+
+                                return replaySummaryDetails
+                            }
+
+                        let replayAll () =
+                            async {
+                                let bugBuckets = IO.DirectoryInfo(replaySourcePath)
+                                if bugBuckets.Exists then
+                                    let! details = replayAndReport (bugBuckets.EnumerateFiles() |> Seq.filter Raft.RESTlerDriver.isBugFile)
+                                    return Some details
+                                else
+                                    printfn "ReplayAll bugBuckets folder does not exist %s" bugBuckets.FullName
+                                    return None
+                            }
+                        let! details =
+                            match restlerPayload.ReplayConfiguration with
+                            | None -> replayAll()
+                            | Some replayConfiguration ->
                                 async {
-                                    let! existingBugBuckets = Raft.RESTlerDriver.getListOfBugsFromBugBuckets replayRunConfiguration.InputFolderPath
-
-                                    let remapBugHashes (bugHashes : Raft.RESTlerTypes.Logs.BugHashes) =
-                                        bugHashes
-                                        |> Seq.map(fun (KeyValue(k, v)) -> v.file_path, k)
-                                        |> Map.ofSeq
-
-                                    let bugs, fileNameToBugHashMap =
-                                        match replayRunConfiguration.IgnoreBugHashes, existingBugBuckets with
-                                        | None, None | Some _, None -> bugs, Map.empty
-                                         | None, Some existingBugs ->
-                                            bugs, (remapBugHashes existingBugs)
-
-                                        | Some ignoreHashes, Some existingBugs ->
-                                            let filesToIgnore = 
-                                                ignoreHashes 
-                                                |> Array.map(fun h ->
-                                                    match Map.tryFind h existingBugs with
-                                                    | None -> None
-                                                    | Some b -> Some b.file_path
-                                                )
-                                                |> Array.filter Option.isSome
-                                                |> Array.map Option.get
-                                                |> Set.ofArray
-
-                                            let filteredBugs =
-                                                bugs
-                                                |> Seq.filter (fun b ->
-                                                    not (filesToIgnore.Contains b.Name)
-                                                )
-                                            filteredBugs, (remapBugHashes existingBugs)
-
-                                    let replaySummaryDetails = ResizeArray<string * string>()
-
-                                    for bug in bugs do
-                                        printfn "Running replay on %s" bug.FullName
-                                        let! (experiment, replaySummary) = replay bug.FullName replayRunConfiguration
-                                        let summary =
-                                            match replaySummary with
-                                            | None ->
-                                                sprintf "%s : No results" bug.Name
-                                            | Some s ->
-                                                sprintf "%s/%s: %A" (Option.defaultValue "ExperimentNotSet" experiment) bug.Name (s.ResponseCodeCounts |> Map.toList)
-
-                                        let bugKey =
-                                            match Map.tryFind bug.Name fileNameToBugHashMap with
-                                            | None -> bug.Name
-                                            | Some h -> h
-                                        replaySummaryDetails.Add(bugKey, summary)
-                                        do! jobEventSender.SendRaftJobEvent jobId
-                                                    ({
-                                                        AgentName = agentName
-                                                        Metadata = None
-                                                        Tool = "RESTler"
-                                                        JobId = jobId
-                                                        State = Raft.JobEvents.JobState.Running
-                                                        Metrics = None
-                                                        UtcEventTime = System.DateTime.UtcNow
-                                                        Details = Some (Map.ofSeq replaySummaryDetails)
-                                                        ResultsUrl = None
-                                                    } : Raft.JobEvents.JobStatus)
-
-                                    return replaySummaryDetails
-                                }
-
-                            let replayAll () =
-                                async {
-                                    let bugBuckets = IO.DirectoryInfo(replaySourcePath)
-                                    if bugBuckets.Exists then
-                                        let! details = replayAndReport (bugBuckets.EnumerateFiles() |> Seq.filter Raft.RESTlerDriver.isBugFile)
+                                    match replayConfiguration.BugBuckets with
+                                    | Some paths ->
+                                        let details = ResizeArray()
+                                        for path in paths do
+                                            let fullPath = replaySourcePath ++ path
+                                            printfn "Full path: %s" fullPath
+                                            let file = IO.FileInfo(fullPath)
+                                            if file.Exists then
+                                                printfn "%s is a file, running replay..." fullPath
+                                                let! d = replayAndReport [file]
+                                                details.AddRange d
+                                            else
+                                                printfn "Replay bugBuckets file does not exist %s" file.FullName
+                                                failwithf "Cannot run replay since could not find %s" fullPath
                                         return Some details
-                                    else
-                                        printfn "ReplayAll bugBuckets folder does not exist %s" bugBuckets.FullName
-                                        return None
+                                    | None -> return! replayAll()
                                 }
-                            let! details =
-                                match restlerPayload.ReplayConfiguration with
-                                | None -> replayAll()
-                                | Some replayConfiguration ->
-                                    async {
-                                        match replayConfiguration.BugBuckets with
-                                        | Some paths ->
-                                            let details = ResizeArray()
-                                            for path in paths do
-                                                let fullPath = replaySourcePath ++ path
-                                                printfn "Full path: %s" fullPath
-                                                let file = IO.FileInfo(fullPath)
-                                                if file.Exists then
-                                                    printfn "%s is a file, running replay..." fullPath
-                                                    let! d = replayAndReport [file]
-                                                    details.AddRange d
-                                                else
-                                                    printfn "Replay bugBuckets file does not exist %s" file.FullName
-                                                    failwithf "Cannot run replay since could not find %s" fullPath
-                                            return Some details
-                                        | None -> return! replayAll()
-                                    }
-                            return Raft.JobEvents.Completed, (details |> Option.map Map.ofSeq), 0, (None, None)
-                with
-                | ex ->
-                    printfn "%A" ex
-                    let! summary = Raft.RESTlerDriver.processRunSummary workDirectory globalRunStartTime
-                    return Raft.JobEvents.Error, (Some (Map.empty.Add("Error",  ex.Message))), 1, summary
-            }
+                        return Raft.JobEvents.TaskCompleted, (details |> Option.map Map.ofSeq), 0, (None, None)
+                }
 
-        let! bugsList = Raft.RESTlerDriver.getListOfBugs workDirectory globalRunStartTime
-        let bugsListLen = match bugsList with None -> 0 | Some xs -> Seq.length xs
+            let! bugsList = Raft.RESTlerDriver.getListOfBugs workDirectory globalRunStartTime
+            let bugsListLen = match bugsList with None -> 0 | Some xs -> Seq.length xs
 
-        let testingSummary = Raft.RESTlerDriver.loadTestRunSummary workDirectory globalRunStartTime
+            let testingSummary = Raft.RESTlerDriver.loadTestRunSummary workDirectory globalRunStartTime
 
-        let details =
-            let d = Option.defaultValue Map.empty details
-            match experiment with
-            | Some e -> Some (d.Add("Experiment", e))
-            | None -> Some d
+            let details =
+                let d = (Option.defaultValue Map.empty details).Add("TaskType", sprintf "%A" restlerTask)
+                match experiment with
+                | Some e -> Some (d.Add("Experiment", e))
+                | None -> Some d
 
-        let details =
-            match testingSummary with
-            | None -> details
-            | Some status ->
-                let d = Option.defaultValue Map.empty details
-                Some( d
-                        .Add("finalSpecCoverage", status.final_spec_coverage)
-                        .Add("numberOfBugsFound", sprintf "%d" bugsListLen)
-                        //.Add("renderedRequests", status.rendered_requests)
-                        //.Add("renderedRequestsValidStatus", status.rendered_requests_valid_status)
-                        //.Add("numFullyValid", sprintf "%d" status.num_fully_valid)
-                        //.Add("numSequenceFailures", sprintf "%d" status.num_sequence_failures)
-                        //.Add("numInvalidByFailedResourceCreations", sprintf "%d" status.num_invalid_by_failed_resource_creations)
-                        //.Add("totalObjectCreations", sprintf "%d" status.total_object_creations)
-                )
+            let details =
+                match testingSummary with
+                | None -> details
+                | Some status ->
+                    let d = Option.defaultValue Map.empty details
+                    Some( d
+                            .Add("finalSpecCoverage", status.final_spec_coverage)
+                            .Add("numberOfBugsFound", sprintf "%d" bugsListLen)
+                            //.Add("renderedRequests", status.rendered_requests)
+                            //.Add("renderedRequestsValidStatus", status.rendered_requests_valid_status)
+                            //.Add("numFullyValid", sprintf "%d" status.num_fully_valid)
+                            //.Add("numSequenceFailures", sprintf "%d" status.num_sequence_failures)
+                            //.Add("numInvalidByFailedResourceCreations", sprintf "%d" status.num_invalid_by_failed_resource_creations)
+                            //.Add("totalObjectCreations", sprintf "%d" status.total_object_creations)
+                    )
 
-        printfn "Sending final event: %A with summary: %A and details %A" state summary details
+            match summary with
+            | Some s -> combinedMetrics := Raft.JobEvents.RunSummary.Combine(!combinedMetrics, s)
+            | None -> ()
+
+            do! jobEventSender.SendRaftJobEvent jobId
+                        ({
+                            AgentName = agentName
+                            Metadata = None
+                            Tool = "RESTler"
+                            JobId = jobId
+                            State = state
+                            Metrics = summary
+                            UtcEventTime = System.DateTime.UtcNow
+                            Details = details
+                            ResultsUrl = None
+                        } : Raft.JobEvents.JobStatus)
+
+
+            // Sending RESTler metrics event as "completed", since from RESTler point of view RESTler run is finished.
+            // From RAFT point of view job is till running, so do not send RAFT Completed event yet
+            let restlerTelemetry = Restler.Telemetry.getDataFromTestingSummary testingSummary
+            telemetryClient.RestlerFinished(
+                Raft.RESTlerDriver.RESTler.version,
+                sprintf "%A" restlerPayload.Task,
+                executionId,
+                sprintf "%A" Raft.JobEvents.JobState.Completed,
+                restlerTelemetry.specCoverageCounts,
+                restlerTelemetry.bugBucketCounts)
+
+
         do! jobEventSender.SendRaftJobEvent jobId
                     ({
                         AgentName = agentName
                         Metadata = None
                         Tool = "RESTler"
                         JobId = jobId
-                        State = state
-                        Metrics = summary
+                        State = Raft.JobEvents.JobState.Completed
+                        Metrics = Some(!combinedMetrics)
                         UtcEventTime = System.DateTime.UtcNow
-                        Details = details
+                        Details = None
                         ResultsUrl = None
                     } : Raft.JobEvents.JobStatus)
 
-        let restlerTelemetry = Restler.Telemetry.getDataFromTestingSummary testingSummary
-        telemetryClient.RestlerFinished(
-            Raft.RESTlerDriver.RESTler.version,
-            sprintf "%A" restlerPayload.Task,
-            executionId,
-            sprintf "%A" state,
-            restlerTelemetry.specCoverageCounts,
-            restlerTelemetry.bugBucketCounts)
-        return exitCode
+        return 0
     } 
     |> Async.Catch
     |> fun result -> 

--- a/src/Agent/RESTlerAgent/RESTlerAgentConfigTypes.fs
+++ b/src/Agent/RESTlerAgent/RESTlerAgentConfigTypes.fs
@@ -58,6 +58,18 @@ type CompileConfiguration =
         CustomDictionary: CustomDictionary option
     }
 
+    static member Empty : CompileConfiguration =
+        {
+            InputJsonGrammarPath = None;
+            InputFolderPath = None;
+            ReadOnlyFuzz = false;
+            AllowGetProducers = false;
+            UseRefreshableToken = false;
+            MutationsSeed = None;
+            CustomDictionary = None
+        }
+
+
 type ReplayConfiguration =
     {
         //list of paths to RESTler folder runs to replay (names of folders are assigned when mounted readonly/readwrite file share mounts)
@@ -93,7 +105,7 @@ type RunConfiguration =
         /// file share is mounted and set here. Agent will not modify
         /// this share. Agent will make a copy of all needed files to it's work directory.
         /// For Replay task: path to RESTler Fuzz or Test run that contains bug buckets to replay
-        InputFolderPath: string
+        InputFolderPath: string option
 
         /// The delay in seconds after invoking an API that creates a new resource
         ProducerTimingDelay : int option
@@ -104,6 +116,8 @@ type RunConfiguration =
         /// Token Refresh Interval
         AuthenticationTokenRefreshIntervalSeconds: int option
 
+        /// RESTler run duration
+        Duration : System.TimeSpan option
         /// Path regex for filtering tested endpoints
         PathRegex : string option
 
@@ -131,6 +145,28 @@ type RunConfiguration =
 
     }
 
+    static member Empty =
+        {
+            GrammarPy = None
+            InputFolderPath = None
+            ProducerTimingDelay = None
+            UseSsl = None
+            AuthenticationTokenRefreshIntervalSeconds = None
+            PathRegex = None
+            IgnoreBugHashes = None
+            MaxRequestExecutionTime = None
+            Checkers = None
+            IgnoreDependencies = None
+            IgnoreFeedback = None
+            IncludeUserAgent = None
+            MaxAsyncResourceCreationTime = None
+            MaxCombinations = None
+            MaxSequenceLength = None
+            WaitForAsyncResourceCreation = None
+            PerResourceSettings = None
+            Duration = None
+        }
+
 
 type AgentConfiguration =
     {
@@ -150,7 +186,7 @@ type TaskType =
 
 type RESTlerPayload =
     {
-        Task: TaskType
+        Task: TaskType option
 
         //Compile task type configuration
         CompileConfiguration: CompileConfiguration option
@@ -164,3 +200,7 @@ type RESTlerPayload =
     }
 
 
+type RESTlerPayloads =
+    {
+        tasks: RESTlerPayload array
+    }

--- a/src/Agent/RESTlerAgent/RESTlerDriver.fs
+++ b/src/Agent/RESTlerAgent/RESTlerDriver.fs
@@ -155,7 +155,7 @@ module private RESTlerInternal =
                     let startedExperiments =
                         experiments 
                         |> Seq.filter ( fun e -> e.CreationTimeUtc >= runStartTime)
-                        |> Seq.sortBy ( fun e -> e.CreationTimeUtc )
+                        |> Seq.sortByDescending ( fun e -> e.CreationTimeUtc )
 
                     if (Seq.length startedExperiments > 1) then
                         printfn "There are : %d [%A] that have been create past %A. Using one closest to start time of this run." 

--- a/src/Contracts/Job.fs
+++ b/src/Contracts/Job.fs
@@ -121,7 +121,6 @@ type JobDefinition =
 
         Resources : Resources
 
-
         // !!NOTE!!: according to Azure Container spec, we can have up to 60 elements
         // of TestTargets and Tasks combined
         TestTargets : TestTarget option

--- a/src/Orchestrator/OrchestratorLogic/Orchestrator.fs
+++ b/src/Orchestrator/OrchestratorLogic/Orchestrator.fs
@@ -1126,6 +1126,9 @@ module ContainerInstances =
                             | JobState.ManuallyStopped ->
                                 Central.Telemetry.TrackMetric(TelemetryValues.Deleted(name, decodedMessage.Message.UtcEventTime), units)
                                 collectToolMetrics()
+                            | JobState.TaskCompleted ->
+                                Central.Telemetry.TrackMetric(TelemetryValues.Completed(name, decodedMessage.Message.UtcEventTime), units)
+                                collectToolMetrics()
                             | JobState.ReStarted | JobState.Creating | JobState.Running | JobState.Completing -> ()
 
                 else

--- a/src/Test/TestInfraFunc/TestInfra.cs
+++ b/src/Test/TestInfraFunc/TestInfra.cs
@@ -55,13 +55,13 @@ namespace TestInfraFunc
             {
                 if (request.Method.ToLowerInvariant() == "get")
                 {
-                    log.LogInformation($"Getting webhook messages for job ${jobId}");
+                    log.LogInformation($"Getting webhook messages for job {jobId}");
                     var results = await TestInfraLogic.WebhooksTest.get(log, StorageTableConnectionString, jobId);
                     return new OkObjectResult(results);
                 }
                 else
                 {
-                    log.LogWarning($"Unhandled request method {request.Method} when job id is ${jobId}");
+                    log.LogWarning($"Unhandled request method {request.Method} when job id is {jobId}");
                     return new BadRequestResult();
                 }
             }


### PR DESCRIPTION
- Enable combination of any RESTler tasks in one job config, thus running specified tasks on single container in succession
- Add new TaskCompleted event to provide more granular status notifications