### PR TITLE
Split each task in RESTler. Every task reports it's own stats, meanwhile Agent overall reports sum of all requests.

### DIFF
--- a/Scripts/Tests/bvt-petstore3.py
+++ b/Scripts/Tests/bvt-petstore3.py
@@ -83,7 +83,8 @@ def bvt(cli, definitions, subs):
         n = 0
         for x in after_compile_pre_fuzz:
             if x['jobId'] == compile_job['jobId']:
-                n += 1
+                if x['state'] == 'Completed':
+                    n += 1
             if x['agentName'] == compile_job['jobId']:
                 if x['state'] != 'Completed':
                     raise Exception('Expected job to be in completed state when retrieved job list.'
@@ -110,7 +111,8 @@ def bvt(cli, definitions, subs):
         m = 0
         for x in after_fuzz:
             if x['jobId'] == fuzz_job['jobId']:
-                m += 1
+                if x['state'] == 'Completed':
+                    m += 1
 
             if x['agentName'] == fuzz_job['jobId']:
                 if x['state'] != 'Completed':


### PR DESCRIPTION
Example:
```Text
Agent: 2-restlercombined    Tool: RESTler    State: Completed     Total Request Count: 701
  Response Code    Count
---------------  -------
            200      227
            400      272
            404       13
            500      189

======================
Agent: 2-restlercombined:0    Tool: RESTler    State: TaskCompleted
Details:
tasktype : Compile
======================
Agent: 2-restlercombined:1    Tool: RESTler    State: TaskCompleted     Total Request Count: 701
  Response Code    Count
---------------  -------
            200      227
            400      272
            404       13
            500      189

Details:
experiment : experiment36
tasktype : Fuzz
finalspeccoverage : 10 / 19
numberofbugsfound : 53
```