### PR TITLE
RESTler token settings #212

### DIFF
--- a/cli/raft_local.py
+++ b/cli/raft_local.py
@@ -701,7 +701,7 @@ class RaftLocalCLI():
             try:
                 self.docker_remove_containers(test_target_container_names)
             except Exception as ex:
-                print(f'Faeild to remove test target containers due to: {ex}')
+                print(f'Failed to remove test target containers due to: {ex}')
 
             try:
                 self.docker_remove_bridge(bridge_name)

--- a/cli/samples/restler/running-against-raft/fuzz.json
+++ b/cli/samples/restler/running-against-raft/fuzz.json
@@ -42,6 +42,7 @@
           "runConfiguration": {
             "inputFolderPath": "/job-compile/RESTler-compile",
             "useSsl": true,
+            "showAuthToken" : true,
             "producerTimingDelay": 5,
             "maxRequestExecutionTime" : 300
           }

--- a/src/Agent/RESTlerAgent/AgentMain.fs
+++ b/src/Agent/RESTlerAgent/AgentMain.fs
@@ -286,6 +286,8 @@ let createRESTlerEngineParameters
         /// Specifies to use SSL when connecting to the server
         UseSsl = match runConfiguration.UseSsl with None -> true | Some useSsl -> useSsl
 
+        ShowAuthToken = match runConfiguration.ShowAuthToken with None -> false | Some showAuthToken -> showAuthToken
+
         /// Path regex for filtering tested endpoints
         PathRegex = runConfiguration.PathRegex
 

--- a/src/Agent/RESTlerAgent/RESTlerAgentConfigTypes.fs
+++ b/src/Agent/RESTlerAgent/RESTlerAgentConfigTypes.fs
@@ -133,6 +133,9 @@ type RunConfiguration =
         /// Specifies to use SSL when connecting to the server
         UseSsl : bool option
 
+        /// Specifies whether to show contents of auth token in RESTler logs
+        ShowAuthToken : bool option
+
         /// Token Refresh Interval
         AuthenticationTokenRefreshIntervalSeconds: int option
 
@@ -185,6 +188,7 @@ type RunConfiguration =
             WaitForAsyncResourceCreation = None
             PerResourceSettings = None
             Duration = None
+            ShowAuthToken = None
         }
 
 

--- a/src/Agent/RESTlerAgent/RESTlerTypes.fs
+++ b/src/Agent/RESTlerAgent/RESTlerTypes.fs
@@ -63,6 +63,9 @@ module Engine =
             /// Specifies to use SSL when connecting to the server
             UseSsl : bool
 
+            /// Specifies whether to show contents of auth token in RESTler logs
+            ShowAuthToken : bool
+
             /// The string to use in overriding the Host for each request
             Host : string option
 
@@ -250,6 +253,7 @@ module Engine =
                     path_regex = p.PathRegex
                     global_producer_timing_delay = p.ProducerTimingDelay
                     no_ssl = not p.UseSsl
+                    no_tokens_in_logs = not p.ShowAuthToken
                     fuzzing_mode = fuzzingMode
                     token_refresh_cmd = tokenRefreshCommand
                     token_refresh_interval = tokenRefreshInterval


### PR DESCRIPTION
Added `ShowAuthToken` field to RESTler run configuration. If set to `true` RESTler will print Authentication token in its network logs.
