### PR TITLE
Restler 8.0.0

### DIFF
--- a/ado/variables/version-variables.yml
+++ b/ado/variables/version-variables.yml
@@ -2,11 +2,11 @@ variables:
   - name: version.major
     value: 4
   - name: version.minor
-    value: 0
-  - name: version.revision
     value: 1
+  - name: version.revision
+    value: 0
   - name: imageTag
-    value: 'v4.0.1'
+    value: 'v4.1.0'
   - name: imageTagLatest
     value: 'v4.latest'
   - name: devRevision

--- a/cli/raft-tools/tools/RESTler/schema.json
+++ b/cli/raft-tools/tools/RESTler/schema.json
@@ -138,6 +138,10 @@
                         "type": "boolean",
                         "description": "Use refreshable token for authenticating with service under test"
                     },
+                    "trackFuzzedParameterNames": {
+                        "type": "boolean",
+                        "description": "True by default. Every fuzzable primitive will include an additional parameter param_name which is the name of the property\r\nor parameter being fuzzed. These will be used to capture fuzzed parameters\r\nin tracked_parameters in the spec coverage file."
+                    },
                     "mutationsSeed": {
                         "type": "integer",
                         "description": "Use the seed to generate random value for empty/null customDictitonary fields\r\nif not set then default hard-coded RESTler values are used for populating customDictionary fields",
@@ -269,6 +273,10 @@
                     "ignoreFeedback":{
                         "type": "boolean",
                         "description": "Ignore feedback from response"
+                    },
+                    "testAllCombinations":{
+                        "type": "boolean",
+                        "description": "By default, test mode will try to execute each request successfully once. This means that, if there are 5 possible values for a parameter, and the request\r\nis successfully executed when passing the first value, the remaining 4 will not be tested.\r\nIn some cases, such as for differential regression testing, it is desired to test all of the specified parameter values in Test mode.\r\nSetting TestAllCombinations to true in test mode in order to try all parameter values\r\n(up to max_combinations).\r\nResults for all parameter combinations will be reported in the spec coverage file."
                     },
                     "includeUserAgent":{
                         "type": "boolean",

--- a/cli/samples/restler/running-against-raft/compile.json
+++ b/cli/samples/restler/running-against-raft/compile.json
@@ -13,6 +13,7 @@
         "toolConfiguration": {
           "task": "compile",
           "compileConfiguration": {
+            "trackFuzzedParameterNames" : true,
             "useRefreshableToken": true,
             "customDictionary": {
               "customPayload": {

--- a/cli/samples/restler/running-against-raft/test.json
+++ b/cli/samples/restler/running-against-raft/test.json
@@ -37,7 +37,8 @@
           "task": "Test",
           "runConfiguration": {
             "inputFolderPath": "/job-compile/RESTler-compile",
-            "maxRequestExecutionTime" : 300
+            "maxRequestExecutionTime" : 300,
+            "testAllCombinations" : true
           }
         }
       }

--- a/cli/samples/restler/self-contained/swagger-petstore/restler.fuzz.json
+++ b/cli/samples/restler/self-contained/swagger-petstore/restler.fuzz.json
@@ -37,7 +37,6 @@
         "toolConfiguration": {
           "task": "Fuzz",
           "runConfiguration": {
-            "useSsl" : false,
             "inputFolderPath": "/job-compile/compile",
             "IgnoreBugHashes" : [
               "PayloadBodyChecker_500_3d6e2d1e897967f3bc14cd8f08252a98b25c4d48",

--- a/cli/samples/restler/self-contained/swagger-petstore/restler.test.json
+++ b/cli/samples/restler/self-contained/swagger-petstore/restler.test.json
@@ -36,7 +36,6 @@
           "toolConfiguration": {
             "task": "Test",
             "runConfiguration": {
-              "useSsl" : false,
               "inputFolderPath": "/job-compile/compile",
               "ignoreBugHashes" : [
                 "PayloadBodyChecker_500_7c2ae3b8c78eabad55a8075b487322dbbe146e46",

--- a/docs/sdk/swagger.md
+++ b/docs/sdk/swagger.md
@@ -748,6 +748,7 @@ set to &#x27;false&#x27; by default.
 In limited cases when GET is a valid producer, the user
 should add an annotation for it. </div>
 <div class="param">useRefreshableToken (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Use refreshable token for authenticating with service under test </div>
+<div class="param">trackFuzzedParameterNames (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> True by default. Every fuzzable primitive will include an additional parameter param_name which is the name of the property or parameter being fuzzed. These will be used to capture fuzzed parameters iin tracked_parameters in the spec coverage file </div>
 <div class="param">mutationsSeed (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> Use the seed to generate random value for empty/null customDictitonary fields
 if not set then default hard-coded RESTler values are used for populating customDictionary fields format: int64</div>
 <div class="param">customDictionary (optional)</div><div class="param-desc"><span class="param-type"><a href="#CustomDictionary">CustomDictionary</a></span>  </div>
@@ -906,6 +907,11 @@ For Replay task: path to RESTler Fuzz or Test run that contains bug buckets to r
 <div class="param">useSsl (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Use SSL when connecting to the server </div>
 <div class="param">pathRegex (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Path regex for filtering tested endpoints </div>
 <div class="param">authenticationTokenRefreshIntervalSeconds (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> Authentciation token refresh interval format: int32</div>
+<div class="param">ignoreBugHashes (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> List of bug hashes to ignore when posting Bug Found webhook </div>
+<div class="param">maxRequestExecutionTime (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> Maximum request execution time </div>
+<div class="param">ignoreDependencies (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Ignore resource dependencies </div>
+<div class="param">ignoreFeedback (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Ignore feedback from responses </div>
+<div class="param">testAllCombinations (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> By default, test mode will try to execute each request successfully once. This means that, if there are 5 possible values for a parameter, and the request is successfully executed when passing the first value, the remaining 4 will not be tested. In some cases, such as for differential regression testing, it is desired to test all of the specified parameter values in Test mode. Setting TestAllCombinations to true in test mode in order to try all parameter values (up to max_combinations). Results for all parameter combinations will be reported in the spec coverage file </div>
 </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/src/Agent/Dockerfile
+++ b/src/Agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/restlerfuzzer/restler:v7.4.0
+FROM mcr.microsoft.com/restlerfuzzer/restler:v8.0.0
 COPY RestlerAgent /raft/agent
 COPY RaftResultAnalyzer /raft/result-analyzer
 COPY RESTler2Postman /raft/restler2postman 

--- a/src/Agent/RESTlerAgent/AgentMain.fs
+++ b/src/Agent/RESTlerAgent/AgentMain.fs
@@ -223,17 +223,18 @@ let createRESTlerEngineParameters
     (task: Raft.Job.RaftTask) (checkerOptions:(string*string) list)
     (runConfiguration: RunConfiguration) (authenicationUrl: System.Uri) : Raft.RESTlerTypes.Engine.EngineParameters =
     
-    let host, ip, port =
+    let useSsl, host, ip, port =
         match task.TargetConfiguration with
-        | None -> None, None, None
+        | None -> true, None, None, None
         | Some targetConfig ->
             match targetConfig.Endpoint with
-            | None -> None, None, None
+            | None -> true, None, None, None
             | Some endpoint ->
+                let useSsl = String.Compare("https", endpoint.Scheme, true) = 0
                 match endpoint.HostNameType with
-                | System.UriHostNameType.Dns ->
-                    Some(endpoint.Host), None, Some(endpoint.Port)
-                | _ -> None, Some(endpoint.Host), Some(endpoint.Port)
+                | System.UriHostNameType.Dns -> 
+                    useSsl, Some(endpoint.Host), None, Some(endpoint.Port)
+                | _ -> useSsl, None, Some(endpoint.Host), Some(endpoint.Port)
 
     {
         /// File path to the REST-ler (python) grammar.
@@ -284,7 +285,7 @@ let createRESTlerEngineParameters
         CheckerOptions = checkerOptions
  
         /// Specifies to use SSL when connecting to the server
-        UseSsl = Option.defaultValue true runConfiguration.UseSsl
+        UseSsl = Option.defaultValue useSsl runConfiguration.UseSsl
 
         ShowAuthToken = Option.defaultValue false runConfiguration.ShowAuthToken
 

--- a/src/Agent/RESTlerAgent/RESTlerAgentConfigTypes.fs
+++ b/src/Agent/RESTlerAgent/RESTlerAgentConfigTypes.fs
@@ -67,6 +67,8 @@ type CompileConfiguration =
         UseBodyExamples : bool
         UseQueryExamples : bool
         IncludeOptionalParameters : bool
+
+        TrackFuzzedParameterNames : bool option
     }
 
     static member Empty : CompileConfiguration =
@@ -87,6 +89,7 @@ type CompileConfiguration =
             UseBodyExamples = true
             UseQueryExamples = true
             IncludeOptionalParameters = true
+            TrackFuzzedParameterNames = None
         }
 
 
@@ -136,6 +139,9 @@ type RunConfiguration =
         /// Specifies whether to show contents of auth token in RESTler logs
         ShowAuthToken : bool option
 
+        /// Specifies whether to test all combinations in 'test' mode
+        TestAllCombinations : bool option
+
         /// Token Refresh Interval
         AuthenticationTokenRefreshIntervalSeconds: int option
 
@@ -173,6 +179,7 @@ type RunConfiguration =
             GrammarPy = None
             InputFolderPath = None
             ProducerTimingDelay = None
+            TestAllCombinations = None
             UseSsl = None
             AuthenticationTokenRefreshIntervalSeconds = None
             PathRegex = None

--- a/src/Agent/RESTlerAgent/RESTlerDriver.fs
+++ b/src/Agent/RESTlerAgent/RESTlerDriver.fs
@@ -7,7 +7,7 @@ open System
 open Microsoft.FSharpLu
 
 module RESTler =
-    let version = "7.4.0"
+    let version = "8.0.0"
 
 module private RESTlerInternal =
     let inline (++) (path1: string) (path2 : string) = IO.Path.Join(path1, path2)

--- a/src/Agent/RESTlerAgent/RESTlerTypes.fs
+++ b/src/Agent/RESTlerAgent/RESTlerTypes.fs
@@ -334,6 +334,11 @@ module Compiler =
             // In limited cases when GET is a valid producer, the user
             // should add an annotation for it.
             AllowGetProducers : bool
+
+            // When this switch is on, the generated grammar will contain
+            // parameter names for all fuzzable values.  For example:
+            // restler_fuzzable_string("1", param_name="num_items")
+            TrackFuzzedParameterNames: bool
         }
     
     type MutationsDictionary =


### PR DESCRIPTION
- Increment RAFT version to 4.1.0
- Expose newly added RESTler options: `trackFuzzedParameterNames` and `testAllCombinations`
- Set RESTler "useSSL" flag based on endpoint definition #192